### PR TITLE
[FEAT] 온보딩 회원정보 입력 api 추가

### DIFF
--- a/src/main/java/com/goat/server/auth/application/AuthService.java
+++ b/src/main/java/com/goat/server/auth/application/AuthService.java
@@ -1,11 +1,13 @@
 package com.goat.server.auth.application;
 
+import com.goat.server.auth.dto.OnBoardingRequest;
 import com.goat.server.auth.dto.response.ReIssueSuccessResponse;
 import com.goat.server.global.util.jwt.JwtUserDetails;
 import com.goat.server.global.util.jwt.JwtTokenProvider;
 import com.goat.server.mypage.domain.User;
 import com.goat.server.mypage.exception.UserNotFoundException;
 import com.goat.server.mypage.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -37,5 +39,17 @@ public class AuthService {
                 .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
 
         return JwtUserDetails.from(user);
+    }
+
+    @Transactional
+    public void saveOnBoardingInfo(Long userId, OnBoardingRequest onBoardingRequest) {
+        log.info("[AuthService.saveOnBoardingInfo]");
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
+
+        user.updateOnBoardingInfo(onBoardingRequest.nickname(), onBoardingRequest.goal());
+
+        userRepository.save(user);
     }
 }

--- a/src/main/java/com/goat/server/auth/dto/OnBoardingRequest.java
+++ b/src/main/java/com/goat/server/auth/dto/OnBoardingRequest.java
@@ -1,0 +1,7 @@
+package com.goat.server.auth.dto;
+
+public record OnBoardingRequest(
+        String nickname,
+        String goal
+) {
+}

--- a/src/main/java/com/goat/server/auth/presentation/AuthController.java
+++ b/src/main/java/com/goat/server/auth/presentation/AuthController.java
@@ -1,6 +1,7 @@
 package com.goat.server.auth.presentation;
 
 import com.goat.server.auth.application.AuthService;
+import com.goat.server.auth.dto.OnBoardingRequest;
 import com.goat.server.auth.dto.response.ReIssueSuccessResponse;
 import com.goat.server.global.dto.ResponseTemplate;
 import com.goat.server.auth.application.KakaoSocialService;
@@ -12,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "AuthController", description = "AuthController 관련 API")
@@ -58,5 +60,19 @@ public class AuthController {
         log.info("[AuthController.testToken]");
 
         return authService.getTestToken(userId);
+    }
+
+    @Operation(summary = "온보딩 회원정보 입력", description = "온보딩 회원정보 입력")
+    @PatchMapping("/info")
+    public ResponseEntity<ResponseTemplate<Object>> saveOnBoardingInfo(@AuthenticationPrincipal Long userId,
+                                                               @RequestBody OnBoardingRequest onBoardingRequest) {
+
+        log.info("[AuthController.saveOnBoardingInfo]");
+
+        authService.saveOnBoardingInfo(userId, onBoardingRequest);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseTemplate.from(ResponseTemplate.EMPTY_RESPONSE));
     }
 }

--- a/src/main/java/com/goat/server/mypage/domain/User.java
+++ b/src/main/java/com/goat/server/mypage/domain/User.java
@@ -75,4 +75,10 @@ public class User extends BaseTimeEntity {
         this.provider = provider;
         this.goal = goal;
     }
+
+    public void updateOnBoardingInfo(String nickname, String goal) {
+        this.nickname = nickname;
+        this.goal = goal;
+        this.role = Role.USER;
+    }
 }

--- a/src/test/java/com/goat/server/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/goat/server/auth/application/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.goat.server.auth.application;
 
+import com.goat.server.auth.dto.OnBoardingRequest;
 import com.goat.server.auth.dto.response.ReIssueSuccessResponse;
 import com.goat.server.global.util.jwt.JwtUserDetails;
 import com.goat.server.global.util.jwt.Tokens;
@@ -16,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import static com.goat.server.mypage.fixture.UserFixture.USER_GUEST;
 import static com.goat.server.mypage.fixture.UserFixture.USER_USER;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
@@ -46,6 +48,21 @@ class AuthServiceTest {
 
         // then
         assertEquals("reIssuedAccessToken", reIssueSuccessResponse.accessToken());
+    }
+
+    @Test
+    @DisplayName("온보딩 회원정보 입력 테스트")
+    void saveOnBoardingInfo() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.of(USER_GUEST));
+
+        // when
+        authService.saveOnBoardingInfo(1L, new OnBoardingRequest("modifiedNickname", "modifiedGoal"));
+
+        // then
+        assertEquals("modifiedNickname", USER_GUEST.getNickname());
+        assertEquals("modifiedGoal", USER_GUEST.getGoal());
+        assertEquals(Role.USER, USER_GUEST.getRole());
     }
 
 

--- a/src/test/java/com/goat/server/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/goat/server/auth/presentation/AuthControllerTest.java
@@ -1,13 +1,16 @@
 package com.goat.server.auth.presentation;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.goat.server.auth.application.AuthService;
 import com.goat.server.auth.application.KakaoSocialService;
+import com.goat.server.auth.dto.OnBoardingRequest;
 import com.goat.server.auth.dto.response.ReIssueSuccessResponse;
 import com.goat.server.auth.dto.response.SignUpSuccessResponse;
 import com.goat.server.global.CommonControllerTest;
 import com.goat.server.global.util.jwt.Tokens;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -32,6 +35,9 @@ class AuthControllerTest extends CommonControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
 
     @Test
     @DisplayName("소셜 로그인 테스트")
@@ -80,4 +86,20 @@ class AuthControllerTest extends CommonControllerTest {
                 .andExpect(jsonPath("$.results.refreshToken").value("refreshToken"));
 
     }
+
+    @Test
+    @DisplayName("온보딩 회원정보 입력 테스트")
+    void saveOnBoardingInfo() throws Exception {
+        //given
+
+        //when
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.patch("/goat/auth/info")
+                .content(objectMapper.writeValueAsString(new OnBoardingRequest("nickname", "안녕하세요!")))
+                .contentType("application/json"));
+
+        //then
+        resultActions
+                .andExpect(status().isOk());
+    }
+
 }


### PR DESCRIPTION
## 관련 이슈

- Resolves #19

## 개요

> 온보딩 회원 정보 입력 기능 구현 

## 작업 사항

- AuthController.saveOnBoardingInfo()
- AuthService.saveOnBoardingInfo()

## Check List
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
