### PR TITLE
[FEAT] 제목 검색 기능 구현 및 폴더 영구 삭제 기능 추가

### DIFF
--- a/src/main/java/com/goat/server/directory/application/DirectoryService.java
+++ b/src/main/java/com/goat/server/directory/application/DirectoryService.java
@@ -39,7 +39,7 @@ public class DirectoryService {
         List<DirectoryResponse> directoryResponseList = getDirectoryResponseList(userId, directoryId, sort);
         List<ReviewSimpleResponse> reviewSimpleResponseList = reviewService.getReviewSimpleResponseList(directoryId, sort);
 
-        return DirectoryTotalShowResponse.of(directoryResponseList, reviewSimpleResponseList);
+        return DirectoryTotalShowResponse.of(directoryId, directoryResponseList, reviewSimpleResponseList);
     }
 
     /**

--- a/src/main/java/com/goat/server/directory/application/DirectoryService.java
+++ b/src/main/java/com/goat/server/directory/application/DirectoryService.java
@@ -14,7 +14,6 @@ import com.goat.server.mypage.domain.User;
 import com.goat.server.review.application.ReviewService;
 import com.goat.server.review.dto.response.ReviewSimpleResponse;
 import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -56,6 +55,8 @@ public class DirectoryService {
         Directory directory = directoryRepository.findById(directoryId)
                 .orElseThrow(() -> new DirectoryNotFoundException(DirectoryErrorCode.DIRECTORY_NOT_FOUND));
 
+        directory.validateUser(userId);
+
         directory.touchParentDirectories();
 
         directoryRepository.findTrashDirectoryByUser(userId)
@@ -76,9 +77,7 @@ public class DirectoryService {
         Directory directory = directoryRepository.findById(directoryId)
                 .orElseThrow(() -> new DirectoryNotFoundException(DirectoryErrorCode.DIRECTORY_NOT_FOUND));
 
-        if (!Objects.equals(directory.getUser().getUserId(), userId)) {
-            throw new DirectoryNotFoundException(DirectoryErrorCode.DIRECTORY_NOT_FOUND);
-        }
+        directory.validateUser(userId);
 
         directory.touchParentDirectories();
         directoryRepository.delete(directory);

--- a/src/main/java/com/goat/server/directory/application/DirectoryService.java
+++ b/src/main/java/com/goat/server/directory/application/DirectoryService.java
@@ -14,6 +14,7 @@ import com.goat.server.mypage.domain.User;
 import com.goat.server.review.application.ReviewService;
 import com.goat.server.review.dto.response.ReviewSimpleResponse;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -64,6 +65,23 @@ public class DirectoryService {
                             log.error("trash directory not found");
                             throw new DirectoryNotFoundException(DirectoryErrorCode.DIRECTORY_NOT_FOUND);
                         });
+    }
+
+    /**
+     * 폴더 영구 삭제
+     */
+    @Transactional
+    public void deleteDirectoryPermanent(Long userId, Long directoryId) {
+
+        Directory directory = directoryRepository.findById(directoryId)
+                .orElseThrow(() -> new DirectoryNotFoundException(DirectoryErrorCode.DIRECTORY_NOT_FOUND));
+
+        if (!Objects.equals(directory.getUser().getUserId(), userId)) {
+            throw new DirectoryNotFoundException(DirectoryErrorCode.DIRECTORY_NOT_FOUND);
+        }
+
+        directory.touchParentDirectories();
+        directoryRepository.delete(directory);
     }
 
     /**

--- a/src/main/java/com/goat/server/directory/application/type/SortType.java
+++ b/src/main/java/com/goat/server/directory/application/type/SortType.java
@@ -10,19 +10,19 @@ public enum SortType {
     NAME_ASC,
     NAME_DESC,
     CREATED_AT,
-    UPDATED_AT
+    MOST_REVIEWED,
     ;
 
     public static final Map<SortType, Function<QDirectory, OrderSpecifier<?>>> DIRECTORY_SORT_MAP = Map.of(
             SortType.CREATED_AT, dir -> dir.createdDate.desc(),
-            SortType.UPDATED_AT, dir -> dir.modifiedDate.desc(),
+            SortType.MOST_REVIEWED, dir -> dir.modifiedDate.desc(),
             SortType.NAME_ASC, dir -> dir.title.asc(),
             SortType.NAME_DESC, dir -> dir.title.desc()
     );
 
     public static final Map<SortType, Function<QReview, OrderSpecifier<?>>> REVIEW_SORT_MAP = Map.of(
             SortType.CREATED_AT, review -> review.createdDate.desc(),
-            SortType.UPDATED_AT, review -> review.modifiedDate.desc(),
+            SortType.MOST_REVIEWED, review -> review.reviewCnt.desc(),
             SortType.NAME_ASC, review -> review.title.asc(),
             SortType.NAME_DESC, review -> review.title.desc()
     );

--- a/src/main/java/com/goat/server/directory/domain/Directory.java
+++ b/src/main/java/com/goat/server/directory/domain/Directory.java
@@ -78,4 +78,10 @@ public class Directory extends BaseTimeEntity {
             this.parentDirectory.touchParentDirectories();
         }
     }
+
+    public void validateUser(Long userId) {
+        if (!this.getUser().getUserId().equals(userId)) {
+            throw new IllegalArgumentException("해당 폴더에 대한 권한이 없습니다.");
+        }
+    }
 }

--- a/src/main/java/com/goat/server/directory/domain/Directory.java
+++ b/src/main/java/com/goat/server/directory/domain/Directory.java
@@ -2,6 +2,7 @@ package com.goat.server.directory.domain;
 
 import com.goat.server.global.domain.BaseTimeEntity;
 import com.goat.server.mypage.domain.User;
+import com.goat.server.review.domain.Review;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -48,6 +49,9 @@ public class Directory extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "parentDirectory", cascade = CascadeType.REMOVE)
     private List<Directory> childDirectoryList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "directory", cascade = CascadeType.REMOVE)
+    private List<Review> reviewList = new ArrayList<>();
 
     @Builder
     public Directory(String title, String directoryColor, Long depth, User user, Directory parentDirectory) {

--- a/src/main/java/com/goat/server/directory/dto/request/DirectoryMoveRequest.java
+++ b/src/main/java/com/goat/server/directory/dto/request/DirectoryMoveRequest.java
@@ -1,7 +1,10 @@
 package com.goat.server.directory.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
 public record DirectoryMoveRequest(
-        Long moveDirectoryId,
-        Long targetDirectoryId
+        @Positive Long moveDirectoryId,
+        @NotNull Long targetDirectoryId
 ) {
 }

--- a/src/main/java/com/goat/server/directory/dto/response/DirectoryTotalShowResponse.java
+++ b/src/main/java/com/goat/server/directory/dto/response/DirectoryTotalShowResponse.java
@@ -4,11 +4,14 @@ import com.goat.server.review.dto.response.ReviewSimpleResponse;
 import java.util.List;
 
 public record DirectoryTotalShowResponse(
+        Long parentDirectoryId,
         List<DirectoryResponse> directoryResponseList,
         List<ReviewSimpleResponse> reviewSimpleResponseList
 ) {
-    public static DirectoryTotalShowResponse of(List<DirectoryResponse> directoryResponseList,
-                                                List<ReviewSimpleResponse> reviewSimpleResponseList) {
-        return new DirectoryTotalShowResponse(directoryResponseList, reviewSimpleResponseList);
+    public static DirectoryTotalShowResponse of(
+            Long parentDirectoryId,
+            List<DirectoryResponse> directoryResponseList,
+            List<ReviewSimpleResponse> reviewSimpleResponseList) {
+        return new DirectoryTotalShowResponse(parentDirectoryId, directoryResponseList, reviewSimpleResponseList);
     }
 }

--- a/src/main/java/com/goat/server/directory/exception/DirectoryCanNotDeleteException.java
+++ b/src/main/java/com/goat/server/directory/exception/DirectoryCanNotDeleteException.java
@@ -1,0 +1,11 @@
+package com.goat.server.directory.exception;
+
+import com.goat.server.global.exception.errorcode.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class DirectoryCanNotDeleteException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/goat/server/directory/exception/errorcode/DirectoryErrorCode.java
+++ b/src/main/java/com/goat/server/directory/exception/errorcode/DirectoryErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum DirectoryErrorCode implements ErrorCode {
 
     DIRECTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "Directory not found."),
+    DIRECTORY_CANNOT_DELETE(HttpStatus.FORBIDDEN, "Directory cannot delete."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/goat/server/directory/presentation/DirectoryController.java
+++ b/src/main/java/com/goat/server/directory/presentation/DirectoryController.java
@@ -8,6 +8,7 @@ import com.goat.server.global.dto.ResponseTemplate;
 import com.goat.server.directory.application.DirectoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,9 +38,11 @@ public class DirectoryController {
     public ResponseEntity<ResponseTemplate<Object>> getDirectorySubList(
             @AuthenticationPrincipal Long userId,
             @RequestParam(defaultValue = "0") Long directoryId,
-            @RequestParam(required = false) List<SortType> sort) {
+            @RequestParam(required = false) List<SortType> sort,
+            @RequestParam(required = false) String search) {
 
-        DirectoryTotalShowResponse directorySubList = directoryService.getDirectorySubList(userId, directoryId, sort);
+        DirectoryTotalShowResponse directorySubList =
+                directoryService.getDirectorySubList(userId, directoryId, sort, search);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -75,7 +78,7 @@ public class DirectoryController {
     @Operation(summary = "폴더 이동", description = "폴더 이동")
     @PostMapping("/move")
     public ResponseEntity<ResponseTemplate<Object>> moveDirectory(
-            @RequestBody DirectoryMoveRequest directoryMoveRequest) {
+            @Valid @RequestBody DirectoryMoveRequest directoryMoveRequest) {
 
         directoryService.moveDirectory(directoryMoveRequest);
 

--- a/src/main/java/com/goat/server/directory/presentation/DirectoryController.java
+++ b/src/main/java/com/goat/server/directory/presentation/DirectoryController.java
@@ -75,6 +75,19 @@ public class DirectoryController {
                 .body(ResponseTemplate.EMPTY_RESPONSE);
     }
 
+    @Operation(summary = "폴더 영구 삭제", description = "폴더 영구 삭제")
+    @DeleteMapping("/permanent/{directoryId}")
+    public ResponseEntity<ResponseTemplate<Object>> deleteDirectoryPermanent(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long directoryId) {
+
+        directoryService.deleteDirectoryPermanent(userId, directoryId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseTemplate.EMPTY_RESPONSE);
+    }
+
     @Operation(summary = "폴더 이동", description = "폴더 이동")
     @PostMapping("/move")
     public ResponseEntity<ResponseTemplate<Object>> moveDirectory(

--- a/src/main/java/com/goat/server/directory/repository/DirectoryRepositoryCustom.java
+++ b/src/main/java/com/goat/server/directory/repository/DirectoryRepositoryCustom.java
@@ -8,4 +8,6 @@ public interface DirectoryRepositoryCustom {
     List<Directory> findAllByParentDirectoryId(Long parentDirectoryId, List<SortType> sort);
 
     List<Directory> findAllByUserIdAndParentDirectoryIsNull(Long userId, List<SortType> sort);
+
+    List<Directory> findAllBySearch(Long userId, String search, List<SortType> sort);
 }

--- a/src/main/java/com/goat/server/directory/repository/DirectoryRepositoryImpl.java
+++ b/src/main/java/com/goat/server/directory/repository/DirectoryRepositoryImpl.java
@@ -6,14 +6,16 @@ import static com.goat.server.directory.domain.QDirectory.directory;
 import com.goat.server.directory.application.type.SortType;
 import com.goat.server.directory.domain.Directory;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.ObjectUtils;
 
 @Repository
 @RequiredArgsConstructor
-public class DirectoryRepositoryImpl implements DirectoryRepositoryCustom{
+public class DirectoryRepositoryImpl implements DirectoryRepositoryCustom {
 
     private final JPAQueryFactory query;
 
@@ -33,6 +35,22 @@ public class DirectoryRepositoryImpl implements DirectoryRepositoryCustom{
                 .where(directory.parentDirectory.id.isNull(), directory.user.userId.eq(userId))
                 .orderBy(sortExpression(sort))
                 .fetch();
+    }
+
+    @Override
+    public List<Directory> findAllBySearch(Long userId, String search, List<SortType> sort) {
+        return query
+                .selectFrom(directory)
+                .where(directory.user.userId.eq(userId), searchExpression(search))
+                .orderBy(sortExpression(sort))
+                .fetch();
+    }
+
+    private BooleanExpression searchExpression(String search) {
+        if (ObjectUtils.isEmpty(search)) {
+            return null;
+        }
+        return directory.title.contains(search);
     }
 
     // 기본 정렬 - 이름 오름차순

--- a/src/main/java/com/goat/server/directory/repository/init/DirectoryInitializer.java
+++ b/src/main/java/com/goat/server/directory/repository/init/DirectoryInitializer.java
@@ -40,21 +40,21 @@ public class DirectoryInitializer implements ApplicationRunner {
             List<Directory> directoryList = new ArrayList<>();
 
             Directory DUMMY_TRASH_DIRECTORY1 = Directory.builder()
-                    .title("trash_directory1")
+                    .title("trash_directory")
                     .directoryColor("#FF00FF")
                     .depth(1L)
                     .parentDirectory(null)
                     .user(admin)
                     .build();
             Directory DUMMY_TRASH_DIRECTORY2 = Directory.builder()
-                    .title("trash_directory2")
+                    .title("trash_directory")
                     .directoryColor("#FF00FF")
                     .depth(1L)
                     .parentDirectory(null)
                     .user(user)
                     .build();
             Directory DUMMY_TRASH_DIRECTORY3 = Directory.builder()
-                    .title("trash_directory3")
+                    .title("trash_directory")
                     .directoryColor("#FF00FF")
                     .depth(1L)
                     .parentDirectory(null)

--- a/src/main/java/com/goat/server/global/application/S3Uploader.java
+++ b/src/main/java/com/goat/server/global/application/S3Uploader.java
@@ -7,7 +7,7 @@ import com.goat.server.global.domain.ImageInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -18,7 +18,7 @@ import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
-@Service
+@Component
 public class S3Uploader {
 
     private final AmazonS3 amazonS3Client;

--- a/src/main/java/com/goat/server/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/goat/server/global/exception/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.goat.server.global.exception.handler;
 
+import com.goat.server.directory.exception.DirectoryCanNotDeleteException;
 import com.goat.server.directory.exception.DirectoryNotFoundException;
 import com.goat.server.mypage.exception.UserNotFoundException;
 import java.util.List;
@@ -39,6 +40,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(DirectoryNotFoundException.class)
     public ResponseEntity<Object> handleDirectoryNotFound(final DirectoryNotFoundException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        return handleExceptionInternal(errorCode);
+    }
+
+    @ExceptionHandler(DirectoryCanNotDeleteException.class)
+    public ResponseEntity<Object> handleDirectoryCanNotDelete(final DirectoryCanNotDeleteException e) {
         final ErrorCode errorCode = e.getErrorCode();
         return handleExceptionInternal(errorCode);
     }

--- a/src/main/java/com/goat/server/global/util/ApplicationContextProvider.java
+++ b/src/main/java/com/goat/server/global/util/ApplicationContextProvider.java
@@ -1,0 +1,20 @@
+package com.goat.server.global.util;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApplicationContextProvider implements ApplicationContextAware {
+
+    private static ApplicationContext context;
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) {
+        context = applicationContext;
+    }
+
+    public static ApplicationContext getApplicationContext() {
+        return context;
+    }
+}

--- a/src/main/java/com/goat/server/review/application/ReviewService.java
+++ b/src/main/java/com/goat/server/review/application/ReviewService.java
@@ -17,9 +17,7 @@ import com.goat.server.directory.application.type.SortType;
 import com.goat.server.review.dto.response.ReviewSimpleResponse;
 import com.goat.server.review.repository.ReviewRepository;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +27,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ObjectUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
@@ -47,8 +46,16 @@ public class ReviewService {
     /**
      * 폴더에 속한 리뷰 목록 조회
      */
-    public List<ReviewSimpleResponse> getReviewSimpleResponseList(Long directoryId, List<SortType> sort) {
-        return reviewRepository.findByDirectoryId(directoryId, sort).stream()
+    public List<ReviewSimpleResponse> getReviewSimpleResponseList(
+            Long userId, Long directoryId, List<SortType> sort, String search) {
+
+        if (!ObjectUtils.isEmpty(search)) {
+            return reviewRepository.findAllBySearch(userId, search, sort).stream()
+                    .map(ReviewSimpleResponse::from)
+                    .toList();
+        }
+
+        return reviewRepository.findAllByDirectoryId(directoryId, sort).stream()
                 .map(ReviewSimpleResponse::from)
                 .toList();
     }

--- a/src/main/java/com/goat/server/review/domain/Review.java
+++ b/src/main/java/com/goat/server/review/domain/Review.java
@@ -6,6 +6,7 @@ import com.goat.server.directory.domain.Directory;
 import com.goat.server.mypage.domain.User;
 import com.goat.server.review.domain.type.Date;
 import com.goat.server.review.dto.request.ReviewUpdateRequest;
+import com.goat.server.review.util.ReviewRemoveListener;
 import jakarta.persistence.*;
 
 import java.time.LocalDate;
@@ -23,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@EntityListeners(ReviewRemoveListener.class)
 public class Review extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/goat/server/review/domain/Review.java
+++ b/src/main/java/com/goat/server/review/domain/Review.java
@@ -12,7 +12,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -75,10 +74,13 @@ public class Review extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
+    @Column(name = "review_cnt")
+    private Long reviewCnt;
+
     @Builder
     public Review(ImageInfo imageInfo, String title, Boolean isImageEnroll, String content, Boolean isRepeatable,
                   Boolean isAutoRepeat, LocalTime remindTime, LocalDate reviewStartDate, LocalDate reviewEndDate, Boolean isPostShare,
-                  Directory directory, User user) {
+                  Directory directory, User user, Long reviewCnt) {
         this.imageInfo = imageInfo;
         this.title = title;
         this.isImageEnroll = isImageEnroll;
@@ -91,6 +93,7 @@ public class Review extends BaseTimeEntity {
         this.isPostShare = isPostShare;
         this.directory = directory;
         this.user = user;
+        this.reviewCnt = reviewCnt;
     }
 
     public void setImageInfo(ImageInfo imageInfo){

--- a/src/main/java/com/goat/server/review/repository/ReviewRepository.java
+++ b/src/main/java/com/goat/server/review/repository/ReviewRepository.java
@@ -1,7 +1,6 @@
 package com.goat.server.review.repository;
 
 import com.goat.server.review.domain.Review;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,8 +11,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
-
-    List<Review> findByDirectoryId(Long directoryId);
 
     Optional<Review> findByIdAndUser_UserId(Long reviewId, Long userId);
 

--- a/src/main/java/com/goat/server/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/goat/server/review/repository/ReviewRepositoryCustom.java
@@ -6,5 +6,7 @@ import java.util.List;
 
 public interface ReviewRepositoryCustom {
 
-    List<Review> findByDirectoryId(Long directoryId, List<SortType> sort);
+    List<Review> findAllByDirectoryId(Long directoryId, List<SortType> sort);
+
+    List<Review> findAllBySearch(Long userId, String search, List<SortType> sort);
 }

--- a/src/main/java/com/goat/server/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/goat/server/review/repository/ReviewRepositoryImpl.java
@@ -6,10 +6,12 @@ import static com.goat.server.review.domain.QReview.review;
 import com.goat.server.directory.application.type.SortType;
 import com.goat.server.review.domain.Review;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.ObjectUtils;
 
 @Repository
 @RequiredArgsConstructor
@@ -18,12 +20,28 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     private final JPAQueryFactory query;
 
     @Override
-    public List<Review> findByDirectoryId(Long directoryId, List<SortType> sort) {
+    public List<Review> findAllByDirectoryId(Long directoryId, List<SortType> sort) {
         return query
                 .selectFrom(review)
                 .where(review.directory.id.eq(directoryId))
                 .orderBy(sortExpression(sort))
                 .fetch();
+    }
+
+    @Override
+    public List<Review> findAllBySearch(Long userId, String search, List<SortType> sort) {
+        return query
+                .selectFrom(review)
+                .where(review.user.userId.eq(userId), searchExpression(search))
+                .orderBy(sortExpression(sort))
+                .fetch();
+    }
+
+    private BooleanExpression searchExpression(String search) {
+        if (ObjectUtils.isEmpty(search)) {
+            return null;
+        }
+        return review.title.contains(search);
     }
 
     // 기본 정렬 - 이름 오름차순

--- a/src/main/java/com/goat/server/review/repository/init/ReviewInitializer.java
+++ b/src/main/java/com/goat/server/review/repository/init/ReviewInitializer.java
@@ -56,6 +56,7 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isPostShare(true)
                     .user(user)
                     .directory(dummyTrashDirectory)
+                    .reviewCnt(0L)
                     .build();
 
             Review DUMMY_REVIEW2 = Review.builder()
@@ -71,6 +72,7 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isPostShare(true)
                     .user(user)
                     .directory(dummyParentDirectory)
+                    .reviewCnt(0L)
                     .build();
 
             Review DUMMY_REVIEW3 = Review.builder()
@@ -86,6 +88,7 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isPostShare(true)
                     .user(user)
                     .directory(dummyParentDirectory)
+                    .reviewCnt(0L)
                     .build();
 
             Review DUMMY_REVIEW4 = Review.builder()
@@ -101,6 +104,7 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isPostShare(true)
                     .user(user)
                     .directory(dummyParentDirectory)
+                    .reviewCnt(0L)
                     .build();
 
             Review DUMMY_REVIEW5 = Review.builder()
@@ -115,6 +119,8 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isAutoRepeat(false)
                     .isPostShare(true)
                     .user(user)
+                    .directory(dummyChildDirectory)
+                    .reviewCnt(0L)
                     .build();
 
             Review DUMMY_REVIEW6 = Review.builder()
@@ -130,6 +136,7 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isPostShare(true)
                     .user(user)
                     .directory(dummyChildDirectory)
+                    .reviewCnt(0L)
                     .build();
 
             Review DUMMY_REVIEW7 = Review.builder()
@@ -140,6 +147,7 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isPostShare(true)
                     .user(user)
                     .directory(dummyChildDirectory)
+                    .reviewCnt(0L)
                     .build();
 
             Review DUMMY_REVIEW8 = Review.builder()
@@ -150,6 +158,7 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isPostShare(true)
                     .user(user)
                     .directory(dummyChildDirectory)
+                    .reviewCnt(0L)
                     .build();
 
             Review DUMMY_REVIEW9 = Review.builder()
@@ -160,6 +169,7 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isPostShare(true)
                     .user(user)
                     .directory(dummyChildDirectory)
+                    .reviewCnt(0L)
                     .build();
 
             reviewList.add(DUMMY_REVIEW1);

--- a/src/main/java/com/goat/server/review/repository/init/ReviewInitializer.java
+++ b/src/main/java/com/goat/server/review/repository/init/ReviewInitializer.java
@@ -38,6 +38,8 @@ public class ReviewInitializer implements ApplicationRunner {
             Directory dummyParentDirectory = directoryRepository.findById(4L).orElseThrow();
             Directory dummyChildDirectory = directoryRepository.findById(7L).orElseThrow();
 
+            Directory deleteTestDirectory = directoryRepository.findById(8L).orElseThrow();
+
             User user = userRepository.findByEmail("userEmail")
                     .orElseThrow(() -> new UserNotFoundException(MypageErrorCode.USER_NOT_FOUND));
 
@@ -168,7 +170,12 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isAutoRepeat(false)
                     .isPostShare(true)
                     .user(user)
-                    .directory(dummyChildDirectory)
+                    .directory(deleteTestDirectory)
+                    .imageInfo(ImageInfo.builder()
+                            .imageFileName("bee.jpg")
+                            .imageFolderName("goat")
+                            .imageUrl("https://team-goat-bucket.s3.ap-northeast-2.amazonaws.com/goat/bee.jpg")
+                            .build())
                     .reviewCnt(10L)
                     .build();
 

--- a/src/main/java/com/goat/server/review/repository/init/ReviewInitializer.java
+++ b/src/main/java/com/goat/server/review/repository/init/ReviewInitializer.java
@@ -72,7 +72,7 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isPostShare(true)
                     .user(user)
                     .directory(dummyParentDirectory)
-                    .reviewCnt(0L)
+                    .reviewCnt(1L)
                     .build();
 
             Review DUMMY_REVIEW3 = Review.builder()
@@ -88,7 +88,7 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isPostShare(true)
                     .user(user)
                     .directory(dummyParentDirectory)
-                    .reviewCnt(0L)
+                    .reviewCnt(2L)
                     .build();
 
             Review DUMMY_REVIEW4 = Review.builder()
@@ -104,7 +104,7 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isPostShare(true)
                     .user(user)
                     .directory(dummyParentDirectory)
-                    .reviewCnt(0L)
+                    .reviewCnt(4L)
                     .build();
 
             Review DUMMY_REVIEW5 = Review.builder()
@@ -120,7 +120,7 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isPostShare(true)
                     .user(user)
                     .directory(dummyChildDirectory)
-                    .reviewCnt(0L)
+                    .reviewCnt(3L)
                     .build();
 
             Review DUMMY_REVIEW6 = Review.builder()
@@ -136,7 +136,7 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isPostShare(true)
                     .user(user)
                     .directory(dummyChildDirectory)
-                    .reviewCnt(0L)
+                    .reviewCnt(6L)
                     .build();
 
             Review DUMMY_REVIEW7 = Review.builder()
@@ -147,7 +147,7 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isPostShare(true)
                     .user(user)
                     .directory(dummyChildDirectory)
-                    .reviewCnt(0L)
+                    .reviewCnt(8L)
                     .build();
 
             Review DUMMY_REVIEW8 = Review.builder()
@@ -158,7 +158,7 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isPostShare(true)
                     .user(user)
                     .directory(dummyChildDirectory)
-                    .reviewCnt(0L)
+                    .reviewCnt(9L)
                     .build();
 
             Review DUMMY_REVIEW9 = Review.builder()
@@ -169,7 +169,7 @@ public class ReviewInitializer implements ApplicationRunner {
                     .isPostShare(true)
                     .user(user)
                     .directory(dummyChildDirectory)
-                    .reviewCnt(0L)
+                    .reviewCnt(10L)
                     .build();
 
             reviewList.add(DUMMY_REVIEW1);

--- a/src/main/java/com/goat/server/review/util/ReviewRemoveListener.java
+++ b/src/main/java/com/goat/server/review/util/ReviewRemoveListener.java
@@ -1,0 +1,24 @@
+package com.goat.server.review.util;
+
+import com.goat.server.global.application.S3Uploader;
+import com.goat.server.global.util.ApplicationContextProvider;
+import com.goat.server.review.domain.Review;
+import jakarta.persistence.PreRemove;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+
+
+@NoArgsConstructor
+@Component
+public class ReviewRemoveListener {
+
+    private static S3Uploader s3Uploader;
+
+    @PreRemove
+    public void preRemove(Review target) {
+        if (s3Uploader == null) {
+            s3Uploader = ApplicationContextProvider.getApplicationContext().getBean(S3Uploader.class);
+        }
+        s3Uploader.deleteImage(target.getImageInfo());
+    }
+}

--- a/src/test/java/com/goat/server/directory/application/DirectoryServiceTest.java
+++ b/src/test/java/com/goat/server/directory/application/DirectoryServiceTest.java
@@ -61,12 +61,12 @@ class DirectoryServiceTest {
                 .willReturn(true);
         given(directoryRepository.findAllByParentDirectoryId(eq(PARENT_DIRECTORY1.getId()), any()))
                 .willReturn(List.of(CHILD_DIRECTORY1, CHILD_DIRECTORY2));
-        given(reviewService.getReviewSimpleResponseList(eq(PARENT_DIRECTORY1.getId()), any())).willReturn(
+        given(reviewService.getReviewSimpleResponseList(any(), eq(PARENT_DIRECTORY1.getId()), any(), any())).willReturn(
                 List.of(ReviewSimpleResponse.from(DUMMY_REVIEW1), ReviewSimpleResponse.from(DUMMY_REVIEW2)));
 
         //when
         DirectoryTotalShowResponse directorySubList =
-                directoryService.getDirectorySubList(USER_USER.getUserId(), PARENT_DIRECTORY1.getId(), null);
+                directoryService.getDirectorySubList(USER_USER.getUserId(), PARENT_DIRECTORY1.getId(), null, null);
 
         //then
         assertThat(directorySubList.directoryResponseList())
@@ -82,12 +82,12 @@ class DirectoryServiceTest {
     @DisplayName("과목과 폴더 가져 오기 테스트 - 루트 폴더")
     void getDirectoryListTest2() {
         //given
-        given(directoryRepository.findAllByUserIdAndParentDirectoryIsNull(USER_USER.getUserId(), null))
+        given(directoryRepository.findAllByUserIdAndParentDirectoryIsNull(eq(USER_USER.getUserId()), any()))
                 .willReturn(List.of(PARENT_DIRECTORY1, PARENT_DIRECTORY2));
 
         //when
         DirectoryTotalShowResponse directorySubList =
-                directoryService.getDirectorySubList(USER_USER.getUserId(), 0L, null);
+                directoryService.getDirectorySubList(USER_USER.getUserId(), 0L, null, null);
 
         //then
         assertThat(directorySubList.directoryResponseList())

--- a/src/test/java/com/goat/server/directory/presentation/DirectoryControllerTest.java
+++ b/src/test/java/com/goat/server/directory/presentation/DirectoryControllerTest.java
@@ -58,9 +58,9 @@ class DirectoryControllerTest extends CommonControllerTest {
         List<ReviewSimpleResponse> reviewSimpleResponseList =
                 List.of(ReviewSimpleResponse.from(DUMMY_REVIEW1), ReviewSimpleResponse.from(DUMMY_REVIEW2));
         DirectoryTotalShowResponse directoryTotalShowResponse =
-                DirectoryTotalShowResponse.of(directoryResponseList, reviewSimpleResponseList);
+                DirectoryTotalShowResponse.of(PARENT_DIRECTORY1.getId(), directoryResponseList, reviewSimpleResponseList);
 
-        given(directoryService.getDirectorySubList(anyLong(), eq(PARENT_DIRECTORY1.getId()), any()))
+        given(directoryService.getDirectorySubList(anyLong(), eq(PARENT_DIRECTORY1.getId()), any(), any()))
                 .willReturn(directoryTotalShowResponse);
 
         log.info("directoryTotalShowResponse: {}", directoryTotalShowResponse);

--- a/src/test/java/com/goat/server/directory/presentation/DirectoryControllerTest.java
+++ b/src/test/java/com/goat/server/directory/presentation/DirectoryControllerTest.java
@@ -103,13 +103,28 @@ class DirectoryControllerTest extends CommonControllerTest {
     }
 
     @Test
-    @DisplayName("폴더 삭제")
-    void deleteDirectoryTest() throws Exception {
+    @DisplayName("폴더 임시 삭제")
+    void deleteDirectoryTemporalTest() throws Exception {
         //given
 
         //when
         ResultActions resultActions =
                 mockMvc.perform(delete("/goat/directory/temporal/" + PARENT_DIRECTORY1.getId()))
+                        .andDo(print());
+
+        //then
+        resultActions
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("폴더 임시 삭제")
+    void deleteDirectoryPermanentTest() throws Exception {
+        //given
+
+        //when
+        ResultActions resultActions =
+                mockMvc.perform(delete("/goat/directory/permanent/" + PARENT_DIRECTORY1.getId()))
                         .andDo(print());
 
         //then


### PR DESCRIPTION
## 관련 이슈

- Resolves #1 

## 개요

> 제목 검색 기능 구현 및 폴더 영구 삭제 기능 추가

## 작업 사항

- search에 String이 들어온 경우 전체 폴더, 파일에서 조회
- 본인이 소유한 폴더가 아니면 삭제 불가능
- 폴더를 영구삭제시 해당 폴더 하위 폴더와 파일들 삭제 - 파일의 사진 정보도 함께 삭제

## Check List
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
