### PR TITLE
[FEAT] 알림 목록 출력 기능 추가

### DIFF
--- a/src/main/java/com/goat/server/auth/application/AuthService.java
+++ b/src/main/java/com/goat/server/auth/application/AuthService.java
@@ -50,6 +50,10 @@ public class AuthService {
 
         user.updateOnBoardingInfo(onBoardingRequest.nickname(), onBoardingRequest.goal());
 
+        if(!onBoardingRequest.fcmToken().isBlank()) {
+            user.updateFcmToken(onBoardingRequest.fcmToken());
+        }
+
         userRepository.save(user);
     }
 }

--- a/src/main/java/com/goat/server/auth/dto/OnBoardingRequest.java
+++ b/src/main/java/com/goat/server/auth/dto/OnBoardingRequest.java
@@ -2,6 +2,7 @@ package com.goat.server.auth.dto;
 
 public record OnBoardingRequest(
         String nickname,
-        String goal
+        String goal,
+        String fcmToken
 ) {
 }

--- a/src/main/java/com/goat/server/global/exception/AccessDeniedException.java
+++ b/src/main/java/com/goat/server/global/exception/AccessDeniedException.java
@@ -1,0 +1,11 @@
+package com.goat.server.global.exception;
+
+import com.goat.server.global.exception.errorcode.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AccessDeniedException extends RuntimeException{
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/goat/server/global/exception/errorcode/GlobalErrorCode.java
+++ b/src/main/java/com/goat/server/global/exception/errorcode/GlobalErrorCode.java
@@ -14,6 +14,7 @@ public enum GlobalErrorCode implements ErrorCode {
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included"),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not exists"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "You don't have permission to access this resource"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/goat/server/mypage/application/UserService.java
+++ b/src/main/java/com/goat/server/mypage/application/UserService.java
@@ -10,6 +10,8 @@ import com.goat.server.mypage.domain.type.Role;
 import com.goat.server.mypage.exception.UserNotFoundException;
 import com.goat.server.mypage.exception.errorcode.MypageErrorCode;
 import com.goat.server.mypage.repository.UserRepository;
+import com.goat.server.notification.domain.NotificationSetting;
+import com.goat.server.notification.repository.NotificationSettingRepository;
 import com.goat.server.review.domain.Review;
 import com.goat.server.review.dto.request.ReviewUpdateRequest;
 import com.goat.server.review.exception.ReviewNotFoundException;
@@ -29,6 +31,7 @@ public class UserService {
     private final DirectoryRepository directoryRepository;
     private final UserRepository userRepository;
     private final S3Uploader s3Uploader;
+    private final NotificationSettingRepository notificationSettingRepository;
 
     /**
      * 유저 회원가입
@@ -53,6 +56,15 @@ public class UserService {
                 .depth(1L)
                 .build();
 
+        NotificationSetting notificationSetting = NotificationSetting.builder()
+                .user(user)
+                .isCommentNoti(false)
+                .isPostNoti(false)
+                .isReviewNoti(false)
+                .build();
+
+
+        notificationSettingRepository.save(notificationSetting);
         directoryRepository.save(trashDirectory);
         directoryRepository.save(storageDirectory);
 

--- a/src/main/java/com/goat/server/mypage/application/UserService.java
+++ b/src/main/java/com/goat/server/mypage/application/UserService.java
@@ -44,11 +44,13 @@ public class UserService {
         Directory trashDirectory = Directory.builder()
                 .user(user)
                 .title("trash_directory")
+                .depth(1L)
                 .build();
 
         Directory storageDirectory = Directory.builder()
                 .user(user)
                 .title("storage_directory")
+                .depth(1L)
                 .build();
 
         directoryRepository.save(trashDirectory);

--- a/src/main/java/com/goat/server/mypage/application/UserService.java
+++ b/src/main/java/com/goat/server/mypage/application/UserService.java
@@ -1,6 +1,8 @@
 package com.goat.server.mypage.application;
 
 import com.goat.server.auth.dto.response.KakaoUserResponse;
+import com.goat.server.directory.domain.Directory;
+import com.goat.server.directory.repository.DirectoryRepository;
 import com.goat.server.global.application.S3Uploader;
 import com.goat.server.global.domain.ImageInfo;
 import com.goat.server.mypage.domain.User;
@@ -24,18 +26,33 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 public class UserService {
 
+    private final DirectoryRepository directoryRepository;
     private final UserRepository userRepository;
     private final S3Uploader s3Uploader;
 
     /**
      * 유저 회원가입
      */
+    @Transactional
     public User createUser(final KakaoUserResponse userResponse) {
         User user = User.builder()
                 .socialId(userResponse.id().toString())
                 .nickname(userResponse.getNickname())
                 .role(Role.GUEST)
                 .build();
+
+        Directory trashDirectory = Directory.builder()
+                .user(user)
+                .title("trash_directory")
+                .build();
+
+        Directory storageDirectory = Directory.builder()
+                .user(user)
+                .title("storage_directory")
+                .build();
+
+        directoryRepository.save(trashDirectory);
+        directoryRepository.save(storageDirectory);
 
         return userRepository.save(user);
     }

--- a/src/main/java/com/goat/server/mypage/domain/User.java
+++ b/src/main/java/com/goat/server/mypage/domain/User.java
@@ -130,4 +130,8 @@ public class User extends BaseTimeEntity {
         this.goal = goal;
         this.role = Role.USER;
     }
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
 }

--- a/src/main/java/com/goat/server/notification/application/NotificationService.java
+++ b/src/main/java/com/goat/server/notification/application/NotificationService.java
@@ -20,6 +20,7 @@ import static com.goat.server.mypage.exception.errorcode.MypageErrorCode.USER_NO
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
@@ -33,7 +34,6 @@ public class NotificationService {
         notificationRepository.save(notification);
     }
 
-    @Transactional
     public NotificationResponse getNotifications(Long userId) {
 
             log.info("[NotificationService.getNotifications]");

--- a/src/main/java/com/goat/server/notification/application/NotificationService.java
+++ b/src/main/java/com/goat/server/notification/application/NotificationService.java
@@ -1,5 +1,6 @@
 package com.goat.server.notification.application;
 
+import com.goat.server.global.exception.AccessDeniedException;
 import com.goat.server.mypage.domain.User;
 import com.goat.server.mypage.exception.UserNotFoundException;
 import com.goat.server.mypage.repository.UserRepository;
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.goat.server.global.exception.errorcode.GlobalErrorCode.ACCESS_DENIED;
 import static com.goat.server.mypage.exception.errorcode.MypageErrorCode.USER_NOT_FOUND;
 
 @Slf4j
@@ -46,5 +48,22 @@ public class NotificationService {
                     .toList();
 
             return NotificationResponse.from(notificationComponents);
+    }
+
+    @Transactional
+    public void readNotification(Long userId, Long notificationId) {
+
+        log.info("[NotificationService.readNotification]");
+
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new IllegalArgumentException("Notification not found"));
+
+        if (!notification.getUser().getUserId().equals(userId)) {
+            throw new AccessDeniedException(ACCESS_DENIED);
+        }
+
+        notification.read();
+
+        notificationRepository.save(notification);
     }
 }

--- a/src/main/java/com/goat/server/notification/application/NotificationService.java
+++ b/src/main/java/com/goat/server/notification/application/NotificationService.java
@@ -1,11 +1,19 @@
 package com.goat.server.notification.application;
 
+import com.goat.server.mypage.domain.User;
+import com.goat.server.mypage.exception.UserNotFoundException;
+import com.goat.server.mypage.repository.UserRepository;
 import com.goat.server.notification.domain.Notification;
+import com.goat.server.notification.dto.response.NotificationResponse;
 import com.goat.server.notification.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.goat.server.mypage.exception.errorcode.MypageErrorCode.USER_NOT_FOUND;
 
 @Slf4j
 @Service
@@ -13,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public void saveNotification(Notification notification) {
@@ -20,5 +29,22 @@ public class NotificationService {
         log.info("[NotificationService.saveNotification]");
 
         notificationRepository.save(notification);
+    }
+
+    @Transactional
+    public NotificationResponse getNotifications(Long userId) {
+
+            log.info("[NotificationService.getNotifications]");
+
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
+
+            List<Notification> notifications = notificationRepository.findAllByUser(user);
+
+            List<NotificationResponse.NotificationComponentResponse> notificationComponents = notifications.stream()
+                    .map(NotificationResponse.NotificationComponentResponse::from)
+                    .toList();
+
+            return NotificationResponse.from(notificationComponents);
     }
 }

--- a/src/main/java/com/goat/server/notification/domain/Notification.java
+++ b/src/main/java/com/goat/server/notification/domain/Notification.java
@@ -47,4 +47,8 @@ public class Notification extends BaseTimeEntity {
         this.review = review;
         this.isRead = false;
     }
+
+    public void read() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/com/goat/server/notification/domain/Notification.java
+++ b/src/main/java/com/goat/server/notification/domain/Notification.java
@@ -37,10 +37,14 @@ public class Notification extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Review review;
 
+    @Column(name = "is_read")
+    private Boolean isRead;
+
     @Builder
     public Notification(String content, User user, Review review) {
         this.content = content;
         this.user = user;
         this.review = review;
+        this.isRead = false;
     }
 }

--- a/src/main/java/com/goat/server/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/goat/server/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,32 @@
+package com.goat.server.notification.dto.response;
+
+import com.goat.server.notification.domain.Notification;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record NotificationResponse(
+        List<NotificationComponentResponse> notifications
+) {
+    @Builder
+    public record NotificationComponentResponse(
+            Long reviewId,
+            String reviewBody,
+            Boolean isRead
+    ){
+        public static NotificationComponentResponse from(Notification notification) {
+            return NotificationComponentResponse.builder()
+                    .reviewId(notification.getReview().getId())
+                    .reviewBody(notification.getContent())
+                    .isRead(notification.getIsRead())
+                    .build();
+        }
+    }
+
+    public static NotificationResponse from(List<NotificationComponentResponse> notifications) {
+        return NotificationResponse.builder()
+                .notifications(notifications)
+                .build();
+    }
+}

--- a/src/main/java/com/goat/server/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/goat/server/notification/dto/response/NotificationResponse.java
@@ -11,12 +11,14 @@ public record NotificationResponse(
 ) {
     @Builder
     public record NotificationComponentResponse(
+            Long notificationId,
             Long reviewId,
             String reviewBody,
             Boolean isRead
     ){
         public static NotificationComponentResponse from(Notification notification) {
             return NotificationComponentResponse.builder()
+                    .notificationId(notification.getNoti_id())
                     .reviewId(notification.getReview().getId())
                     .reviewBody(notification.getContent())
                     .isRead(notification.getIsRead())

--- a/src/main/java/com/goat/server/notification/presentation/NotificationController.java
+++ b/src/main/java/com/goat/server/notification/presentation/NotificationController.java
@@ -1,0 +1,38 @@
+package com.goat.server.notification.presentation;
+
+import com.goat.server.global.dto.ResponseTemplate;
+import com.goat.server.notification.application.NotificationService;
+import com.goat.server.notification.dto.response.NotificationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@Tag(name = "NotificationController", description = "NotificationController 관련 API")
+@RequestMapping("/goat/notification")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @Operation(summary = "알림 목록 보기", description = "알림 목록 보기")
+    @GetMapping
+    public ResponseEntity<ResponseTemplate<Object>> getNotifications(@AuthenticationPrincipal Long userId) {
+
+        log.info("[NotificationController.getNotifications]");
+
+        NotificationResponse notification = notificationService.getNotifications(userId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseTemplate.from(notification));
+    }
+}

--- a/src/main/java/com/goat/server/notification/presentation/NotificationController.java
+++ b/src/main/java/com/goat/server/notification/presentation/NotificationController.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,7 +24,7 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
-    @Operation(summary = "알림 목록 보기", description = "알림 목록 보기")
+    @Operation(summary = "알림 목록 출력", description = "알림 목록 보기")
     @GetMapping
     public ResponseEntity<ResponseTemplate<Object>> getNotifications(@AuthenticationPrincipal Long userId) {
 
@@ -34,5 +35,18 @@ public class NotificationController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseTemplate.from(notification));
+    }
+
+    @Operation(summary = "알림 읽음 표시", description = "알림 읽음 표시")
+    @GetMapping("/{notificationId}")
+    public ResponseEntity<ResponseTemplate<Object>> readNotification(@AuthenticationPrincipal Long userId, @PathVariable Long notificationId) {
+
+        log.info("[NotificationController.readNotification]");
+
+        notificationService.readNotification(userId, notificationId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseTemplate.EMPTY_RESPONSE);
     }
 }

--- a/src/main/java/com/goat/server/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/goat/server/notification/repository/NotificationRepository.java
@@ -1,7 +1,12 @@
 package com.goat.server.notification.repository;
 
+import com.goat.server.mypage.domain.User;
 import com.goat.server.notification.domain.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findAllByUser(User user);
 }

--- a/src/test/java/com/goat/server/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/goat/server/auth/application/AuthServiceTest.java
@@ -57,11 +57,12 @@ class AuthServiceTest {
         given(userRepository.findById(1L)).willReturn(Optional.of(USER_GUEST));
 
         // when
-        authService.saveOnBoardingInfo(1L, new OnBoardingRequest("modifiedNickname", "modifiedGoal"));
+        authService.saveOnBoardingInfo(1L, new OnBoardingRequest("modifiedNickname", "modifiedGoal", "fcmToken"));
 
         // then
         assertEquals("modifiedNickname", USER_GUEST.getNickname());
         assertEquals("modifiedGoal", USER_GUEST.getGoal());
+        assertEquals("fcmToken", USER_GUEST.getFcmToken());
         assertEquals(Role.USER, USER_GUEST.getRole());
     }
 

--- a/src/test/java/com/goat/server/auth/application/KakaoSocialServiceTest.java
+++ b/src/test/java/com/goat/server/auth/application/KakaoSocialServiceTest.java
@@ -3,6 +3,7 @@ package com.goat.server.auth.application;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.goat.server.directory.repository.DirectoryRepository;
 import com.goat.server.mypage.repository.UserRepository;
 import com.goat.server.notification.application.FcmServiceImpl;
 import org.junit.jupiter.api.AfterEach;
@@ -16,6 +17,8 @@ import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 import java.util.Map;
 
@@ -43,6 +46,9 @@ class KakaoSocialServiceTest {
     private FcmServiceImpl fcmService;
 
     private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Autowired
+    private DirectoryRepository directoryRepository;
 
     @BeforeEach
     void setUp() {
@@ -84,6 +90,8 @@ class KakaoSocialServiceTest {
 
         //then
         assertNotNull(userRepository.findBySocialId(String.valueOf(1231241)));
+        assertThat(directoryRepository.findTrashDirectoryByUser(1L).get().getTitle()).isEqualTo("trash_directory");
+        assertThat(directoryRepository.findStorageDirectoryByUser(1L).get().getTitle()).isEqualTo("storage_directory");
     }
 
 }

--- a/src/test/java/com/goat/server/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/goat/server/auth/presentation/AuthControllerTest.java
@@ -94,7 +94,7 @@ class AuthControllerTest extends CommonControllerTest {
 
         //when
         ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.patch("/goat/auth/info")
-                .content(objectMapper.writeValueAsString(new OnBoardingRequest("nickname", "안녕하세요!")))
+                .content(objectMapper.writeValueAsString(new OnBoardingRequest("nickname", "안녕하세요!", "fcmToken")))
                 .contentType("application/json"));
 
         //then


### PR DESCRIPTION
## 관련 이슈

- Resolves #25  

## 개요

> 알림 목록 출력 기능 추가, 알림 읽음 기능 추가, 회원 온보딩 정보 입력시 FcmToken을 같이 받도록 수정, 회원 생성시 storage와 trash directory를 같이 생성

## 작업 사항

- 알림 목록 출력 API 구현
- 알림 읽음 API 구현
- 회원 온보딩 정보 입력시, FcmToken을 요청에 포함하도록 수정
- 회원 생성시 storage, trash directory를 생성하도록 수정

## Check List
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
