### PR TITLE
[FEAT] 마이페이지에서 전공관련 조회 및 추가하는 기능을 제거

### DIFF
--- a/src/main/java/com/goat/server/mypage/domain/User.java
+++ b/src/main/java/com/goat/server/mypage/domain/User.java
@@ -91,29 +91,9 @@ public class User extends BaseTimeEntity {
         this.imageInfo = imageInfo;
     }
 
-    //마이페이지에서 세부 내용 업데이트 (닉네임, 학년, 전공)
+    //마이페이지에서 세부 내용 업데이트 (닉네임)
     public void updateMypageDetails(MypageDetailsRequest request) {
         this.nickname = request.nickname();
-        this.grade = request.grade();
-
-        List<String> newMajorNames = request.majorList().stream()
-                .map(String::valueOf)
-                .toList();
-
-        this.majorList.removeIf(existingMajor -> !newMajorNames.contains(existingMajor.getMajorName()));
-
-        // 전공 추가
-        for (String majorName : newMajorNames) {
-            boolean exists = this.majorList.stream()
-                    .anyMatch(existingMajor -> existingMajor.getMajorName().equals(majorName));
-
-            if (!exists) {
-                this.majorList.add(Major.builder()
-                        .majorName(majorName)
-                        .user(this)
-                        .build());
-            }
-        }
     }
 
     //프로필 url 가져오는 메서드

--- a/src/main/java/com/goat/server/mypage/dto/request/MypageDetailsRequest.java
+++ b/src/main/java/com/goat/server/mypage/dto/request/MypageDetailsRequest.java
@@ -1,14 +1,9 @@
 package com.goat.server.mypage.dto.request;
 
-import com.goat.server.mypage.domain.type.Grade;
 import lombok.Builder;
-
-import java.util.List;
 
 @Builder
 public record MypageDetailsRequest(
-        String nickname,
-        Grade grade,
-        List<String> majorList
+        String nickname
 ) {
 }

--- a/src/main/java/com/goat/server/mypage/dto/response/MypageDetailsResponse.java
+++ b/src/main/java/com/goat/server/mypage/dto/response/MypageDetailsResponse.java
@@ -1,24 +1,17 @@
 package com.goat.server.mypage.dto.response;
 
 import com.goat.server.mypage.domain.User;
-import com.goat.server.mypage.domain.type.Grade;
 import lombok.Builder;
-
-import java.util.List;
 
 @Builder
 public record MypageDetailsResponse(
         String imageUrl,
-        String nickname,
-        Grade grade,
-        List<String> majorList
+        String nickname
 ) {
-    public static MypageDetailsResponse of(User user, List<String> majorNames) {
+    public static MypageDetailsResponse from(User user) {
         return MypageDetailsResponse.builder()
                 .imageUrl(user.getProfileImageUrl())
                 .nickname(user.getNickname())
-                .grade(user.getGrade())
-                .majorList(majorNames)
                 .build();
     }
 }

--- a/src/main/java/com/goat/server/mypage/dto/response/MypageHomeResponse.java
+++ b/src/main/java/com/goat/server/mypage/dto/response/MypageHomeResponse.java
@@ -1,27 +1,20 @@
 package com.goat.server.mypage.dto.response;
 
 import com.goat.server.mypage.domain.User;
-import com.goat.server.mypage.domain.type.Grade;
 import lombok.Builder;
-
-import java.util.List;
 
 @Builder
 public record MypageHomeResponse (
         String imageUrl,
         String nickname,
-        Grade grade,
         String goal,
-        Long totalReviewCnt,
-        List<String> majorList
+        Long totalReviewCnt
 ) {
-    public static MypageHomeResponse of(User user, List<String> majorNames, Long totalReviewCnt) {
+    public static MypageHomeResponse of(User user, Long totalReviewCnt) {
         return MypageHomeResponse.builder()
                 .imageUrl(user.getProfileImageUrl())
                 .nickname(user.getNickname())
-                .grade(user.getGrade())
                 .goal(user.getGoal())
-                .majorList(majorNames)
                 .totalReviewCnt(totalReviewCnt)
                 .build();
     }

--- a/src/main/java/com/goat/server/mypage/presentation/MypageController.java
+++ b/src/main/java/com/goat/server/mypage/presentation/MypageController.java
@@ -29,18 +29,18 @@ public class MypageController {
     private final MypageService mypageService;
     private final UserService userService;
 
-    @Operation(summary = "마이페이지 정보 보기", description = "마이페이지 정보 보기")
+    @Operation(summary = "마이페이지 첫화면 정보 보기", description = "마이페이지에서 프로필이미지, 닉네임, 목표, 복습횟수 정보 보기")
     @GetMapping("/info")
     public ResponseEntity<ResponseTemplate<Object>> getMypageAllDetail(@AuthenticationPrincipal Long userId) {
 
-        MypageHomeResponse mypageHomeResponse = mypageService.getUserWithMajors(userId);
+        MypageHomeResponse mypageHomeResponse = mypageService.getMypageHome(userId);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseTemplate.from(mypageHomeResponse));
     }
 
-    @Operation(summary = "마이페이지 세부 정보 보기", description = "마이페이지에서 프로필이미지, 닉네임, 전공, 학년 보기")
+    @Operation(summary = "마이페이지 세부 정보 보기", description = "마이페이지에서 프로필이미지, 닉네임 보기")
     @GetMapping("/info/details")
     public ResponseEntity<ResponseTemplate<Object>> getMypageDetails(@AuthenticationPrincipal Long userId) {
 
@@ -51,7 +51,7 @@ public class MypageController {
                 .body(ResponseTemplate.from(mypageDetailsResponse));
     }
 
-    @Operation(summary = "마이페이지 세부 정보 수정하기", description = "마이페이지에서 닉네임, 전공, 학년 수정하기")
+    @Operation(summary = "마이페이지 세부 정보 수정하기", description = "마이페이지에서 닉네임 수정하기")
     @PutMapping("/info/details")
     public ResponseEntity<ResponseTemplate<Object>> updateUserDetails(
             @AuthenticationPrincipal Long userId,
@@ -64,7 +64,7 @@ public class MypageController {
                 .body(ResponseTemplate.EMPTY_RESPONSE);
     }
 
-    @Operation(summary = "마이페이지 프로필 이미지 수정하기", description = "마이페이지 프로필 이미지 수정하기")
+    @Operation(summary = "마이페이지 프로필 이미지 수정하기", description = "마이페이지에서 프로필 이미지 수정하기")
     @PutMapping (consumes = {MediaType.MULTIPART_FORM_DATA_VALUE}, value ="/info/profile")
     public ResponseEntity<ResponseTemplate<Object>> updateProfileImage(
             @AuthenticationPrincipal Long userId,


### PR DESCRIPTION
## 관련 이슈

- Resolves #29 

## 개요

> 마이페이지 디자인 변경에 따라 마이페이지에서 전공관련 조회 및 추가하는 기능을 제거

## 작업 사항

- 마이페이지에서 전공관련 조회 및 추가하는 기능을 제거

## Check List
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
